### PR TITLE
[refs #34] Added implementation to get users with query parameters

### DIFF
--- a/src/managers/Interfaces/IUserManager.ts
+++ b/src/managers/Interfaces/IUserManager.ts
@@ -9,7 +9,7 @@ export abstract class IUserManager {
     queryValue: string
   ): Promise<User[]>;
 
-  public abstract getUserId(username: string): Promise<string | false>;
+  public abstract getUserId(username: string): Promise<string>;
   protected abstract getRoles(userId: string): Promise<never>;
 
   public abstract create(

--- a/src/managers/Interfaces/IUserManager.ts
+++ b/src/managers/Interfaces/IUserManager.ts
@@ -3,7 +3,13 @@ import { User } from '../../models/user';
 
 export abstract class IUserManager {
   public abstract get(userId: string): Promise<User>;
-  public abstract getUserId(username: string): Promise<string>;
+
+  public abstract getUsers(
+    queryParameter: string,
+    queryValue: string
+  ): Promise<User[]>;
+
+  public abstract getUserId(username: string): Promise<string | false>;
   protected abstract getRoles(userId: string): Promise<never>;
 
   public abstract create(

--- a/src/managers/UserManager.ts
+++ b/src/managers/UserManager.ts
@@ -43,6 +43,39 @@ export default class UserManager extends IUserManager implements IObserver {
     this.realmManager = realmManager;
   }
 
+  /**
+   *
+   * @param queryParameter
+   *   - briefRepresentation: Defines whether brief representations are returned
+   *   - email: User's email
+   *   - emailVerified: whether the email has been verified
+   *   - enabled: User is enabled or not
+   *   - firstName
+   *   - lastName
+   * @param queryValue
+   * @returns { User[] }
+   */
+
+  getUsers = async (
+    queryParameter: string,
+    queryValue: string
+  ): Promise<User[]> => {
+    const headers = HeadersFactory.instance().authorizationHeader(
+      this.accessToken
+    );
+
+    const apiConfig = {
+      url: `${this.url}?${queryParameter}=${queryValue}&exact=true`,
+      method: 'GET',
+      headers: headers,
+      body: {}
+    };
+
+    const response = await requestBuilder(apiConfig);
+
+    return response.data as User[];
+  };
+
   getUserId = async (username: string): Promise<string> => {
     const headers = HeadersFactory.instance().authorizationHeader(
       this.accessToken
@@ -219,7 +252,7 @@ export default class UserManager extends IUserManager implements IObserver {
       url: `${this.url}/${userId}/execute-actions-email`,
       method: 'PUT',
       headers: HeadersFactory.instance().authorizationHeader(this.accessToken),
-      body: `["UPDATE_PASSWORD"]`
+      body: ['UPDATE_PASSWORD']
     };
 
     await requestBuilder(apiConfig);


### PR DESCRIPTION
Also, the body of the forgotten password has changed; instead of sending a string, we are now sending an array with strings. 