### PR TITLE
Verify Email Fix

### DIFF
--- a/src/managers/UserManager.ts
+++ b/src/managers/UserManager.ts
@@ -262,10 +262,10 @@ export default class UserManager extends IUserManager implements IObserver {
 
   public sendVerificationMail = async (userId: string) => {
     const apiConfig = {
-      url: `${this.url}/${userId}/send-verify-email`,
+      url: `${this.url}/${userId}/execute-actions-email`,
       method: 'PUT',
       headers: HeadersFactory.instance().authorizationHeader(this.accessToken),
-      body: {}
+      body: ['VERIFY_EMAIL']
     };
 
     await requestBuilder(apiConfig);
@@ -523,4 +523,3 @@ export default class UserManager extends IUserManager implements IObserver {
     await requestBuilder(apiConfig);
   };
 }
-


### PR DESCRIPTION
Updating API call to send the correct email template when creating a user. The route for the email template we want to use was changed in the new Keycloak versions (v25 and forward)