### PR TITLE
Adding user data to the fuse method

### DIFF
--- a/src/managers/Interfaces/ITokenManager.ts
+++ b/src/managers/Interfaces/ITokenManager.ts
@@ -6,11 +6,6 @@ import { KeycloakLogin } from '../../models/keycloak-login';
 
 export abstract class ITokenManager extends ISubject {
   public abstract initializeManager(keycloakLogin: KeycloakLogin): void;
-  protected abstract makeRefreshRequest({
-    url,
-    method = 'get',
-    headers = {},
-    body
-  }): void;
+  protected abstract makeRefreshRequest({ url, method, headers, body }): void;
   protected abstract refreshAccessToken(): void;
 }

--- a/src/managers/TokenManager.ts
+++ b/src/managers/TokenManager.ts
@@ -80,11 +80,13 @@ export default class TokenManager extends ITokenManager {
 
   protected makeRefreshRequest = async (apiConfig: {
     url;
-    method;
-    headers;
+    method?: string;
+    headers?: Record<string, string>;
     body;
   }): Promise<void> => {
-    const response = await requestBuilder(apiConfig);
+    const { url, method = 'get', headers = {}, body } = apiConfig;
+
+    const response = await requestBuilder({ url, method, headers, body });
 
     this.accessToken = response?.data.access_token;
     this.refreshToken = response?.data.refresh_token;

--- a/src/managers/UserManager.ts
+++ b/src/managers/UserManager.ts
@@ -432,6 +432,14 @@ export default class UserManager extends IUserManager implements IObserver {
       a.access = b.access;
     }
 
+    // Fuse additional fields like email, firstName, lastName, emailVerified, enabled, and totp
+    a.email = a.email || b.email;
+    a.firstName = a.firstName || b.firstName;
+    a.lastName = a.lastName || b.lastName;
+    a.emailVerified = a.emailVerified ?? b.emailVerified;
+    a.enabled = a.enabled ?? b.enabled;
+    a.totp = a.totp ?? b.totp;
+
     return a;
   }
 


### PR DESCRIPTION
In the new keycloak version the basic user data needs to also be specified when updating the user otherwise it will be replaced with null.

I also fixed a build error that had to do with the default values being specified in the interface and moved this defaults to the method implementation