### PR TITLE
Improving token refresh scheduling and handling SSO Session Max timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.5] - 2026-03-11
+
+**Backwards compatible** - No code changes required. The library now requests `offline_access` scope by default; if your Keycloak client doesn't support it, set `requestOfflineAccess: false` in credentials.
+
+### Added
+- **Automatic re-authentication**: When refresh tokens expire (e.g., SSO Session Max timeout), the library re-authenticates automatically using stored credentials
+- **Offline access support**: `offline_access` scope now requested by default for longer-lived sessions (configurable via `requestOfflineAccess`)
+- **Dynamic token refresh scheduling**: Refresh intervals recalculate after each token refresh based on actual expiration times
+- **Infinite loop prevention**: Added `isRefreshing` flag to prevent simultaneous refresh attempts
+- New `requestOfflineAccess` property in `KeycloakLogin` interface (defaults to `true`)
+
+### Fixed
+- **Critical**: Server crashes from expired refresh tokens (400 errors) now caught and handled via re-authentication
+- **Critical**: Infinite loop when tokens too short to schedule near session expiration
+- Memory leaks from stale refresh intervals (now properly cleared before rescheduling)
+- `clientSecret` now conditionally added to request body (only if provided)
+
+### Changed
+- Token refresh now wrapped in try-catch with automatic fallback to re-authentication on failure
+- Credentials (username/password) stored in memory for automatic re-authentication
+- `scheduleTokenRefresh()` extracted as separate method, called after every token refresh
+- Refresh interval calculation improved to handle `refresh_expires_in=0` (offline_access mode)
+- Short token warning (< 60s)
+
+### Documentation
+- Added comprehensive token management guide (`docs/TOKEN_REFRESH.md`)
+- Documented offline_access configuration and SSO session handling

--- a/docs/TOKEN_REFRESH.md
+++ b/docs/TOKEN_REFRESH.md
@@ -1,0 +1,142 @@
+# Token Management
+
+## Overview
+
+Tokens are managed automatically behind the scenes. The library handles token refresh, re-authentication, and session recovery without any manual intervention.
+
+## Basic Usage
+
+```typescript
+import createKeycloakFacade from 'keycloak-typescript';
+
+const keycloakFacade = await createKeycloakFacade(
+    {
+        clientId: 'admin-cli',
+        username: 'your-username',
+        password: 'your-password'
+    },
+    'master',
+    'http://localhost:8080',
+    true
+);
+
+// That's it! Token management is automatic
+const users = await keycloakFacade.userManager.getUsers('username', 'admin');
+```
+
+Your application can now run indefinitely. The library automatically:
+- Refreshes tokens before they expire
+- Re-authenticates when refresh tokens expire
+- Requests `offline_access` scope for longer-lived sessions
+- Adapts to your Keycloak token configuration
+
+## Configuration
+
+### requestOfflineAccess: boolean (default: true)
+
+Controls whether the library requests the `offline_access` scope during authentication. This scope provides longer-lived refresh tokens not tied to SSO idle timeout.
+
+```typescript
+const keycloakFacade = await createKeycloakFacade(
+    {
+        clientId: 'admin-cli',
+        username: 'your-username',
+        password: 'your-password',
+        requestOfflineAccess: false // Disable if needed
+    },
+    'master',
+    'http://localhost:8080',
+    true
+);
+```
+
+**Note:** Without offline access, sessions are limited by your Keycloak SSO Session Max setting.
+
+
+## How It Works
+
+The library uses an internal `TokenManager` that handles all token operations:
+
+1. **Initial Authentication** - When you call `createKeycloakFacade()`, the library authenticates and schedules automatic token refresh
+2. **Automatic Refresh** - Before tokens expire, the library refreshes them automatically using the refresh token
+3. **Re-authentication** - If refresh fails (e.g., SSO session expired), the library re-authenticates using stored credentials
+
+All of this happens transparently. Your code never needs to handle token expiration manually.
+
+## SSO Session Expiration
+
+Keycloak's SSO Session Max setting limits the maximum session lifetime. When this timeout is reached, refresh tokens become invalid. **The library handles this automatically by re-authenticating.**
+
+### Testing
+
+To verify automatic re-authentication works:
+
+1. **Configure short timeouts in Keycloak:**
+   ```
+   Realm Settings → Tokens:
+   - Access Token Lifespan: 1 minute
+   - Refresh Token Max: 3 minutes
+   - SSO Session Max: 5 minutes
+   ```
+
+2. **Run your application:**
+   ```typescript
+   const keycloakFacade = await createKeycloakFacade(credentials, 'master', 'http://localhost:8080', true);
+   
+   setInterval(async () => {
+     const users = await keycloakFacade.userManager.getUsers('username', 'admin');
+     console.log('Users retrieved:', users.length);
+   }, 30000);
+   ```
+
+3. **Expected behavior:**
+   - ✓ Tokens refresh automatically every ~1 minute
+   - ✓ After 5 minutes, re-authentication occurs automatically
+   - ✓ No errors or interruptions
+
+## Keycloak Configuration
+
+To enable `offline_access` scope in Keycloak:
+
+1. Go to Clients → Your Client → Client Scopes
+2. Ensure "Offline Access" is in the assigned default scopes
+3. Configure "Offline Session" settings in Realm Settings → Tokens
+
+## Troubleshooting
+
+### "Cannot re-authenticate: username or password not stored"
+
+**Cause:** Credentials weren't provided during initialization.
+
+**Solution:** Ensure you provide both username and password:
+
+```typescript
+const keycloakFacade = await createKeycloakFacade(
+  {
+    clientId: 'admin-cli',
+    username: 'your-username',  // Required
+    password: 'your-password'   // Required
+  },
+  'master',
+  'http://localhost:8080',
+  true
+);
+```
+
+### Token Refresh Warnings
+
+**Cause:** Token lifetimes are shorter than 60 seconds.
+
+**What Happens:** The library refreshes immediately instead of scheduling.
+
+**Solution (Optional):** Increase token lifetimes in Keycloak for better performance:
+```
+Realm Settings → Tokens:
+- Access Token Lifespan: 5 minutes (recommended minimum)
+- Refresh Token Max: 30 minutes (recommended)
+```
+
+## Additional Resources
+
+- [Keycloak Token Settings Documentation](https://www.keycloak.org/docs/latest/server_admin/#_timeouts)
+- [OAuth 2.0 Offline Access](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -27,6 +27,28 @@ const newUserId = this.keycloakFacade.userManager.create({ // Use example of the
 });
 ```
 
+## Security Best Practices
+
+**Always use environment variables for credentials:**
+
+```ts
+import createKeycloakFacade from 'keycloak-typescript';
+
+const keycloakFacade = await createKeycloakFacade(
+    {
+        clientId: process.env.KEYCLOAK_CLIENT_ID!,
+        username: process.env.KEYCLOAK_USERNAME!,
+        password: process.env.KEYCLOAK_PASSWORD!,
+        clientSecret: process.env.KEYCLOAK_CLIENT_SECRET
+    },
+    process.env.KEYCLOAK_REALM!,
+    process.env.KEYCLOAK_URL!,
+    true
+);
+```
+
+**Note:** The library stores credentials in memory for automatic token refresh and re-authentication. Never hardcode credentials in your source code.
+
 ## Managers
 
 ### User Manager

--- a/src/managers/TokenManager.ts
+++ b/src/managers/TokenManager.ts
@@ -19,6 +19,12 @@ export default class TokenManager extends ITokenManager {
   private refreshTokenExpireTime?: number;
   private clientId?: string;
   private clientSecret?: string;
+  private username?: string;
+  private password?: string;
+  private refreshIntervalId?: NodeJS.Timeout;
+  private requestOfflineAccess: boolean = true;
+  private isRefreshing: boolean = false;
+  private hasWarnedShortTokens: boolean = false;
 
   constructor(url: string, observers?: IObserver[]) {
     super();
@@ -38,14 +44,24 @@ export default class TokenManager extends ITokenManager {
   ): Promise<void> => {
     this.clientSecret = keycloakLogin.clientSecret;
     this.clientId = keycloakLogin.clientId;
+    this.username = keycloakLogin.username;
+    this.password = keycloakLogin.password;
+    this.requestOfflineAccess = keycloakLogin.requestOfflineAccess ?? true;
 
-    const body = {
-      client_id: this.clientId,
+    const body: Record<string, string> = {
+      client_id: this.clientId!,
       username: keycloakLogin.username,
       password: keycloakLogin.password,
-      client_secret: this.clientSecret,
       grant_type: 'password'
     };
+
+    if (this.clientSecret) {
+      body.client_secret = this.clientSecret;
+    }
+
+    if (this.requestOfflineAccess) {
+      body.scope = 'offline_access';
+    }
 
     const apiConfig = {
       url: this.url,
@@ -56,26 +72,7 @@ export default class TokenManager extends ITokenManager {
 
     await this.makeRefreshRequest(apiConfig);
 
-    //Create timed task to refresh token
-    const marginInSeconds = 60;
-    if (
-      this.accessTokenExpireTime != undefined &&
-      this.refreshTokenExpireTime != undefined
-    ) {
-      const accessTokenInterval = this.accessTokenExpireTime - marginInSeconds;
-      const refreshTokenInterval =
-        this.refreshTokenExpireTime - marginInSeconds;
-
-      if (accessTokenInterval > refreshTokenInterval) {
-        setInterval(() => {
-          this.refreshAccessToken();
-        }, refreshTokenInterval * 1000);
-      } else {
-        setInterval(() => {
-          this.refreshAccessToken();
-        }, accessTokenInterval * 1000);
-      }
-    }
+    this.scheduleTokenRefresh();
   };
 
   protected makeRefreshRequest = async (apiConfig: {
@@ -98,21 +95,163 @@ export default class TokenManager extends ITokenManager {
   };
 
   protected refreshAccessToken = async (): Promise<void> => {
-    const body = {
-      client_id: this.clientId,
-      client_secret: this.clientSecret,
-      refresh_token: this.refreshToken,
-      grant_type: 'refresh_token'
-    };
+    // Prevent multiple simultaneous refresh attempts
+    if (this.isRefreshing) {
+      return;
+    }
 
-    const apiConfig = {
-      url: this.url,
-      method: 'POST',
-      headers: {},
-      body: querystring.stringify(body)
-    };
+    this.isRefreshing = true;
 
-    await this.makeRefreshRequest(apiConfig);
+    try {
+      const body = {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        refresh_token: this.refreshToken,
+        grant_type: 'refresh_token'
+      };
+
+      const apiConfig = {
+        url: this.url,
+        method: 'POST',
+        headers: {},
+        body: querystring.stringify(body)
+      };
+
+      await this.makeRefreshRequest(apiConfig);
+
+      // Reschedule the refresh based on new expiration times
+      this.scheduleTokenRefresh();
+    } catch (error) {
+      // If refresh token is expired or invalid, re-authenticate with password grant
+      // eslint-disable-next-line no-console
+      console.error(
+        'Token refresh failed, attempting re-authentication:',
+        error
+      );
+      await this.reauthenticateWithPassword();
+    } finally {
+      this.isRefreshing = false;
+    }
+  };
+
+  /**
+   * Re-authenticate using the password grant type when refresh token expires
+   */
+  protected reauthenticateWithPassword = async (): Promise<void> => {
+    if (!this.username || !this.password) {
+      throw new Error(
+        'Cannot re-authenticate: username or password not stored'
+      );
+    }
+
+    try {
+      const body: Record<string, string> = {
+        client_id: this.clientId!,
+        username: this.username,
+        password: this.password,
+        grant_type: 'password'
+      };
+
+      if (this.clientSecret) {
+        body.client_secret = this.clientSecret;
+      }
+
+      if (this.requestOfflineAccess) {
+        body.scope = 'offline_access';
+      }
+
+      const apiConfig = {
+        url: this.url,
+        method: 'POST',
+        headers: {},
+        body: querystring.stringify(body)
+      };
+
+      await this.makeRefreshRequest(apiConfig);
+
+      this.isRefreshing = false;
+
+      this.scheduleTokenRefresh();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Re-authentication failed:', error);
+      this.isRefreshing = false;
+      throw error;
+    }
+  };
+
+  /**
+   * Schedule token refresh based on the expiration times returned by Keycloak
+   */
+  protected scheduleTokenRefresh = (): void => {
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId);
+      this.refreshIntervalId = undefined;
+    }
+
+    if (this.accessTokenExpireTime == undefined) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Cannot schedule token refresh: accessTokenExpireTime is undefined'
+      );
+      return;
+    }
+
+    if (!this.hasWarnedShortTokens && this.accessTokenExpireTime < 60) {
+      this.hasWarnedShortTokens = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Access token lifespan is very short. This will cause frequent refreshes.',
+        {
+          accessTokenExpireTime: this.accessTokenExpireTime,
+          recommendation:
+            'Recommended: at least 1 minute for development, 5+ minutes for production'
+        }
+      );
+    }
+
+    // Use a dynamic margin that's a percentage of token lifetime (min 5s, max 60s)
+    // This prevents issues when tokens have very short lifespans
+    const marginInSeconds = Math.min(
+      Math.max(Math.floor(this.accessTokenExpireTime * 0.2), 5),
+      60
+    );
+    const minimumIntervalSeconds = 10;
+
+    const accessTokenInterval = this.accessTokenExpireTime - marginInSeconds;
+
+    let refreshInterval: number;
+
+    if (
+      this.refreshTokenExpireTime == undefined ||
+      this.refreshTokenExpireTime === 0
+    ) {
+      // refresh_expires_in is 0 or not provided
+      // Using offline_access or SSO session settings
+      refreshInterval = accessTokenInterval;
+    } else {
+      const refreshTokenInterval =
+        this.refreshTokenExpireTime - marginInSeconds;
+
+      // Use the shorter interval to ensure we always refresh before expiration
+      refreshInterval = Math.min(accessTokenInterval, refreshTokenInterval);
+    }
+
+    if (refreshInterval > 0) {
+      refreshInterval = Math.max(refreshInterval, minimumIntervalSeconds);
+
+      this.refreshIntervalId = setInterval(() => {
+        this.refreshAccessToken();
+      }, refreshInterval * 1000);
+    } else {
+      // Token too short to schedule safely - attempt immediate refresh
+      // This will likely trigger re-authentication
+      setTimeout(() => {
+        if (!this.isRefreshing) {
+          this.refreshAccessToken();
+        }
+      }, 1000);
+    }
   };
 
   protected notify = (): void => {

--- a/src/models/keycloak-login.ts
+++ b/src/models/keycloak-login.ts
@@ -3,4 +3,5 @@ export interface KeycloakLogin {
   username: string;
   password: string;
   clientSecret?: string;
+  requestOfflineAccess?: boolean;
 }


### PR DESCRIPTION
Fixes #42 

## Root cause
Refresh token logic wasn't handling the case for SSO Session Max timeout, refresh interval was fixed to 60s so it didn't work with tokens that expire within a minute time or less.

## Solution 

1.- Implemented Error Handling: Now the token manager re-authenticates when the token expires.
2.- Implemented Dynamic Expiration Handling: Instead of assuming fixed expiration times, the library now calculates token refresh intervals based on the actual expires_in and refresh_expires_in values returned by Keycloak
3.- Implemented use of offline_access Scope: This allows to obtain new access token and a new SSO session even after SSO Session Max timeout elapsed.